### PR TITLE
 Fixed stylesheet and script paths for cronmon installations which are in a subdirectory

### DIFF
--- a/config/livewire.php
+++ b/config/livewire.php
@@ -42,7 +42,7 @@ return [
     |
     */
 
-    'asset_url'  => '/cronmon',
+    'asset_url'  => env('LIVEWIRE_ASSET_URL', null),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/livewire.php
+++ b/config/livewire.php
@@ -1,0 +1,76 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Class Namespace
+    |--------------------------------------------------------------------------
+    |
+    | This value sets the root namespace for Livewire component classes in
+    | your application. This value effects component auto-discovery and
+    | any livewire file helper commands, like `artisan make:livewire`.
+    |
+    | After changing this item, run: `php artisan livewire:discover`
+    |
+    */
+
+    'class_namespace' => 'App\\Http\\Livewire',
+
+    /*
+    |--------------------------------------------------------------------------
+    | View Path
+    |--------------------------------------------------------------------------
+    |
+    | This value sets the path for Livewire component views. This effects
+    | File manipulation helper commands like `artisan make:livewire`
+    |
+    */
+
+    'view_path' => resource_path('views/livewire'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Livewire Assets URL
+    |--------------------------------------------------------------------------
+    |
+    | This value sets the path to Livewire JavaScript assets, for cases where
+    | your app's domain root is not the correct path. By default, Livewire
+    | will load its JavaScript assets from the app's "relative root".
+    |
+    | Examples: "/assets", "myurl.com/app"
+    |
+    */
+
+    'asset_url'  => '/cronmon',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Livewire Endpoint Middleware Group
+    |--------------------------------------------------------------------------
+    |
+    | This value sets the middleware group that will be applied to the main
+    | Livewire "message" endpoint (the endpoint that gets hit everytime,
+    | a Livewire component updates). It is set to "web" by default.
+    |
+    */
+
+    'middleware_group'  => 'web',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Manifest File Path
+    |--------------------------------------------------------------------------
+    |
+    | This value sets the path to Livewire manifest file path.
+    | The default should work for most cases (which is
+    | "<app_root>/bootstrap/cache/livewire-components.php)", but for specific
+    | cases like when hosting on Laravel Vapor, it could be set to a different value.
+    |
+    | Example: For Laravel Vapor, it would be "/tmp/storage/bootstrap/cache/livewire-components.php"
+    |
+    */
+
+    'manifest_path' => null,
+
+];

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,10 +11,10 @@
     <title>{{ config('app.name', 'Laravel') }}</title>
 
     <!-- Styles -->
-    <link href="/css/animate.css" rel="stylesheet">
-    <link href="/css/cronmon.css" rel="stylesheet">
+    <link href="{{ asset('css/animate.css') }}" rel="stylesheet">
+    <link href="{{ asset('css/cronmon.css') }}" rel="stylesheet">
 
-    <link rel="shortcut icon" href="/favicon.ico">
+    <link rel="shortcut icon" href="{{ asset('favicon.ico') }}">
     <!-- Scripts -->
     <script>
         window.Laravel = @json(['csrfToken' => csrf_token()])
@@ -33,7 +33,7 @@
 
     </div>
 
-    <script src="/js/app.js"></script>
+    <script src="{{ asset('/js/app.js') }}"></script>
     @livewireScripts
 </body>
 </html>

--- a/resources/views/partials/navbar.blade.php
+++ b/resources/views/partials/navbar.blade.php
@@ -1,7 +1,7 @@
 <nav class="flex items-center justify-between flex-wrap border-b-2 border-orange bg-grey-lightest p-6 shadow">
   <div class="md:flex md:flex-grow md:items-center">
     <div class="">
-      <a class="font-semibold pr-4 text-orange-dark hover:text-orange-dark text-xl tracking-tight" href="/">
+      <a class="font-semibold pr-4 text-orange-dark hover:text-orange-dark text-xl tracking-tight" href="{{ URL::to('/') }}">
         {{ config('app.name') }}
       </a>
     </div>


### PR DESCRIPTION
Hi,

I just wanted to run cronmon on my server under server.com/cronmon besides some other applications. I made the necessary changes and tested them on my server.

Would be nice if you could put this on the main repository.

Thanks!